### PR TITLE
Etape 6 : NOUVELLE FONCTIONNALITE - Une tâche doit être attachée à un utilisateur

### DIFF
--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -63,14 +63,18 @@ class TaskController extends AbstractController
     }
 
     #[Route('/tasks/{id}/edit', name: 'task_edit')]
-    public function edit(Task $task, Request $request, EntityManagerInterface $entityManager, UserRepository $userRepository)
+    public function edit(Task $task, Request $request, EntityManagerInterface $entityManager)
     {
         //création du formulaire grâce à la méthode createForm() du contrôleur
         $form = $this->createForm(TaskEditionFormType::class, $task);
+        //on récupère l'auteur initial de la tâche
+        $initialAuthor = $task->getUser();
         //on récupère les données du formulaire
         $form->handleRequest($request);
         //si le formulaire est soumis et valide
         if ($form->isSubmitted() && $form->isValid()) {
+            //on rattache l'auteur initial à la tâche qu'on est en train de modifier
+            $task->setUser($initialAuthor);
             //on persiste la tâche et on la flush
             $entityManager->persist($task);
             $entityManager->flush();

--- a/src/Form/TaskEditionFormType.php
+++ b/src/Form/TaskEditionFormType.php
@@ -3,6 +3,8 @@
 namespace App\Form;
 
 use App\Entity\Task;
+use App\Entity\User;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -33,6 +35,12 @@ class TaskEditionFormType extends AbstractType
                   ]),
                 ],
               ])
+              ->add('user', EntityType::class, [  // champ autheur de la tache en disabled car on ne veut pas le modifier
+                'class' => User::class,
+                'choice_label' => 'username',
+                'disabled' => true,
+                'placeholder' => 'Anonyme',
+            ]);
         ;
     }
 

--- a/templates/task/edit.html.twig
+++ b/templates/task/edit.html.twig
@@ -29,6 +29,15 @@
                 }}
                 {{form_errors(form.content)}}
 
+                {{ form_row(form.user, {
+                    'attr': {
+                        'class': 'form-control',
+                        'placeholder': 'Anonyme',
+                    },
+                    'label': 'Auteur',
+                    'disabled': true,
+                }) }}
+
                     <button type="submit" class="btn btn-success btn-submit">Modifier</button>
 
                 {{ form_end(form) }}


### PR DESCRIPTION
Rappel : 
_Il vous est demandé d’apporter les corrections nécessaires afin qu’automatiquement, à la sauvegarde de la tâche, l’utilisateur authentifié soit rattaché à la tâche nouvellement créée. Lors de la modification de la tâche, l’auteur ne peut pas être modifié._

La relation entre table user et task déjà réalisée lors de la refonte au début cf etape 1

Dans controller à la fonction edit on récupère l'auteur initial et quand on modifie on le set à cet auteur initial 
Dans le form de l'edit rajout du champ auteur en disabled uniquement pour la modification et mise en place dans la vue