### PR TITLE
Etape 7 : NOUVELLE FONCTIONNALITE - Choisir un rôle pour un utilisateur

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -9,6 +9,11 @@ security:
             entity:
                 class: App\Entity\User
                 property: email
+
+    role_hierarchy:
+        ROLE_USER: ['ROLE_USER']
+        ROLE_ADMIN: ['ROLE_ADMIN'] 
+
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -53,7 +53,7 @@ public function create(Request $request, UserPasswordHasherInterface $userPasswo
     }
 
     return $this->render('user/create.html.twig', [
-        'userCreationForm' => $form->createView(),
+        'form' => $form->createView(),
     ]);
 }
 
@@ -80,7 +80,7 @@ public function edit(User $user, Request $request, EntityManagerInterface $entit
  }
 
  return $this->render('user/edit.html.twig', [
-     'userEditionForm' => $form->createView(),
+     'form' => $form->createView(),
      'user' => $user, 
  ]);
 }

--- a/src/Form/userCreationFormType.php
+++ b/src/Form/userCreationFormType.php
@@ -4,10 +4,12 @@ namespace App\Form;
 
 use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Length;
@@ -18,48 +20,83 @@ class userCreationFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-        ->add('email', EmailType::class, [
-            'attr' => ['class'=>'form-control'],
-            'label' => 'E-mail',
-            'constraints' => [
-              new NotBlank([
-                'message' => 'Renseignez un E-mail.',
-              ]),
-            ],
-          ])
-          ->add('username',TextType::class, [
-            'attr' => ['class'=>'form-control'],
-            'label' => 'Nom d\'utilisateur',
-            'constraints' => [
-              new NotBlank([
-                'message' => 'Renseignez un nom d\'utilisateur.',
-              ]),
-            ],
-          ])
-          ->add('password', RepeatedType::class, [
-            'type' => PasswordType::class,
-            'invalid_message' => 'Les deux mots de passe doivent correspondre.',
-            'required' => true,
-            'first_options' => [
-                'label' => 'Mot de passe',
-                'attr' => ['class' => 'form-control'], 
-            ],
-            'second_options' => [
-                'label' => 'Tapez le mot de passe à nouveau',
-                'attr' => ['class' => 'form-control'], 
-            ],
-            'constraints' => [
-                new NotBlank([
-                    'message' => 'Please enter a password',
-                ]),
-                new Length([
-                    'min' => 6,
-                    'minMessage' => 'Votre mot de passe doit contenir au moins {{ limit }} caractères',
-                    'max' => 254,
-                ]),
-            ],
-        ])
+            ->add('email', EmailType::class, [
+                'attr' => ['class' => 'form-control'],
+                'label' => 'E-mail',
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Renseignez un E-mail.',
+                    ]),
+                ],
+            ])
+            ->add('username', TextType::class, [
+                'attr' => ['class' => 'form-control'],
+                'label' => 'Nom d\'utilisateur',
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Renseignez un nom d\'utilisateur.',
+                    ]),
+                ],
+            ])
+            ->add('roles', ChoiceType::class, [
+                'label' => 'Rôle',
+                'attr' => ['class' => 'form-control'],
+                'choices' => [
+                    'Utilisateur' => 'ROLE_USER',
+                    'Administrateur' => 'ROLE_ADMIN',
+                ],
+                'expanded' => false, 
+                'multiple' => false,
+            ])
+
+            ->add('password', RepeatedType::class, [
+                'type' => PasswordType::class,
+                'invalid_message' => 'Les deux mots de passe doivent correspondre.',
+                'required' => true,
+                'first_options' => [
+                    'label' => 'Mot de passe',
+                    'attr' => ['class' => 'form-control'],
+                ],
+                'second_options' => [
+                    'label' => 'Tapez le mot de passe à nouveau',
+                    'attr' => ['class' => 'form-control'],
+                ],
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Please enter a password',
+                    ]),
+                    new Length([
+                        'min' => 6,
+                        'minMessage' => 'Votre mot de passe doit contenir au moins {{ limit }} caractères',
+                        'max' => 254,
+                    ]),
+                ],
+            ])
         ;
+
+        $builder->get('roles')
+        //on ajoute un model transformer pour transformer les données de l'entité pour le formulaire
+        //et on fait appel à la classe CallbackTransformer qui permet de transformer les données grace à deux fonctions anonymes
+        //utile pour transformer les données de l'entité pour le formulaire et inversement quand elle ne correspondent pas
+            ->addModelTransformer(new CallbackTransformer(
+                /* Cette fonction transforme les données de l'entité pour le formulaire
+            Prend en entrée un tableau, $rolesArray, qui représente les rôles de l'utilisateur*/
+                function ($rolesArray) {
+                    //Vérifie si $rolesArray est bien un tableau et qu'il contient au moins un élément
+                    if (is_array($rolesArray) && count($rolesArray) > 0) {
+                        // Si les conditions sont remplies, on retourne le premier élément du tableau. Car role unique
+                        return $rolesArray[0];
+                    }
+                    // Si $rolesArray n'est pas un tableau ou est vide, on retourne null
+                    return null;
+                },
+                // Cette fonction fait l'inverse de la première : elle transforme les données du formulaire pour l'entité
+                //Prend en entrée une chaîne de caractères, qui représente le rôle sélectionné
+                function ($rolesString) {
+                    // Transforme la chaîne de caractères en tableau car l'entité attend un tableau de rôles.
+                    return [$rolesString];
+                }
+            ));
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/userEditionFormType.php
+++ b/src/Form/userEditionFormType.php
@@ -4,66 +4,103 @@ namespace App\Form;
 
 use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Email;
 
 class userEditionFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-        ->add('email', EmailType::class, [
-            'attr' => ['class'=>'form-control'],
-            'label' => 'E-mail',
-            'constraints' => [
-              new NotBlank([
-                'message' => 'Renseignez un E-mail.',
-              ]),
-              new Email([
-                'message' => 'L\'adresse e-mail "{{ value }}" n\'est pas valide.',
-            ]),
-            ],
-          ])
-          ->add('username',TextType::class, [
-            'attr' => ['class'=>'form-control'],
-            'label' => 'Nom d\'utilisateur',
-            'constraints' => [
-              new NotBlank([
-                'message' => 'Renseignez un nom d\'utilisateur.',
-              ]),
-            ],
-          ])
-          ->add('password', RepeatedType::class, [
-            'type' => PasswordType::class,
-            'invalid_message' => 'Les deux mots de passe doivent correspondre.',
-            'required' => true,
-            'first_options' => [
-                'label' => 'Mot de passe',
-                'attr' => ['class' => 'form-control'], 
-            ],
-            'second_options' => [
-                'label' => 'Tapez le mot de passe à nouveau',
-                'attr' => ['class' => 'form-control'], 
-            ],
-            'constraints' => [
-                new NotBlank([
-                    'message' => 'Please enter a password',
-                ]),
-                new Length([
-                    'min' => 6,
-                    'minMessage' => 'Votre mot de passe doit contenir au moins {{ limit }} caractères',
-                    'max' => 254,
-                ]),
-            ],
-        ])
+            ->add('email', EmailType::class, [
+                'attr' => ['class' => 'form-control'],
+                'label' => 'E-mail',
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Renseignez un E-mail.',
+                    ]),
+                    new Email([
+                        'message' => 'L\'adresse e-mail "{{ value }}" n\'est pas valide.',
+                    ]),
+                ],
+            ])
+            ->add('username', TextType::class, [
+                'attr' => ['class' => 'form-control'],
+                'label' => 'Nom d\'utilisateur',
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Renseignez un nom d\'utilisateur.',
+                    ]),
+                ],
+            ])
+            ->add('roles', ChoiceType::class, [
+                'label' => 'Rôle',
+                'attr' => ['class' => 'form-control'],
+                'choices' => [
+                    'Utilisateur' => 'ROLE_USER',
+                    'Administrateur' => 'ROLE_ADMIN',
+                ],
+                'expanded' => false,
+                'multiple' => false,
+            ])
+
+            ->add('password', RepeatedType::class, [
+                'type' => PasswordType::class,
+                'invalid_message' => 'Les deux mots de passe doivent correspondre.',
+                'required' => true,
+                'first_options' => [
+                    'label' => 'Mot de passe',
+                    'attr' => ['class' => 'form-control'],
+                ],
+                'second_options' => [
+                    'label' => 'Tapez le mot de passe à nouveau',
+                    'attr' => ['class' => 'form-control'],
+                ],
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Please enter a password',
+                    ]),
+                    new Length([
+                        'min' => 6,
+                        'minMessage' => 'Votre mot de passe doit contenir au moins {{ limit }} caractères',
+                        'max' => 254,
+                    ]),
+                ],
+            ])
         ;
+        $builder->get('roles')
+        //on ajoute un model transformer pour transformer les données de l'entité pour le formulaire
+        //et on fait appel à la classe CallbackTransformer qui permet de transformer les données grace à deux fonctions anonymes
+        //utile pour transformer les données de l'entité pour le formulaire et inversement quand elle ne correspondent pas
+            ->addModelTransformer(new CallbackTransformer(
+                /* Cette fonction transforme les données de l'entité pour le formulaire
+            Prend en entrée un tableau, $rolesArray, qui représente les rôles de l'utilisateur*/
+                function ($rolesArray) {
+                    //Vérifie si $rolesArray est bien un tableau et qu'il contient au moins un élément
+                    if (is_array($rolesArray) && count($rolesArray) > 0) {
+                        // Si les conditions sont remplies, on retourne le premier élément du tableau. Car role unique
+                        return $rolesArray[0];
+                    }
+                    // Si $rolesArray n'est pas un tableau ou est vide, on retourne null
+                    return null;
+                },
+                // Cette fonction fait l'inverse de la première : elle transforme les données du formulaire pour l'entité
+                //Prend en entrée une chaîne de caractères, qui représente le rôle sélectionné
+                function ($rolesString) {
+                    // Transforme la chaîne de caractères en tableau car l'entité attend un tableau de rôles.
+                    return [$rolesString];
+                }
+            ));
+
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/templates/user/create.html.twig
+++ b/templates/user/create.html.twig
@@ -4,36 +4,44 @@
 {% block body %}
 <div class="container">
     <h3>Créer un utilisateur</h3>
-    {{ form_start(userCreationForm, {'attr': {'novalidate': 'novalidate'}}) }}
+    {{ form_start(form, {'attr': {'novalidate': 'novalidate'}}) }}
     
     <div class="form-group">
-        {{ form_label(userCreationForm.email) }}
-        {{ form_widget(userCreationForm.email, {'attr': {'class': 'form-control'}}) }}
-        {{ form_errors(userCreationForm.email) }}
+        {{ form_label(form.email) }}
+        {{ form_widget(form.email, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.email) }}
     </div>
 
     <div class="form-group">
-        {{ form_label(userCreationForm.username) }}
-        {{ form_widget(userCreationForm.username, {'attr': {'class': 'form-control'}}) }}
-        {{ form_errors(userCreationForm.username) }}
+        {{ form_label(form.username) }}
+        {{ form_widget(form.username, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.username) }}
+    </div>
+
+    
+    <div class="form-group">
+        {{ form_label(form.roles) }}
+        {{ form_widget(form.roles, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.roles) }}
+    </div>
+
+
+    <div class="form-group">
+        {{ form_label(form.password.first) }}
+        {{ form_widget(form.password.first, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.password.first) }}
     </div>
 
     <div class="form-group">
-        {{ form_label(userCreationForm.password.first) }}
-        {{ form_widget(userCreationForm.password.first, {'attr': {'class': 'form-control'}}) }}
-        {{ form_errors(userCreationForm.password.first) }}
-    </div>
-
-    <div class="form-group">
-        {{ form_label(userCreationForm.password.second) }}
-        {{ form_widget(userCreationForm.password.second, {'attr': {'class': 'form-control'}}) }}
-        {{ form_errors(userCreationForm.password.second) }}
+        {{ form_label(form.password.second) }}
+        {{ form_widget(form.password.second, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.password.second) }}
     </div>
 
     <div class="form-group">
         <button type="submit" class="btn btn-success">Enregistrer</button>
     </div>
 
-    {{ form_end(userCreationForm) }}
+    {{ form_end(form) }}
 </div>
 {% endblock %}

--- a/templates/user/edit.html.twig
+++ b/templates/user/edit.html.twig
@@ -6,37 +6,43 @@
 {% block body %}
 <div class="container">
     <h3>Édition de l'utilisateur</h3>
-    {{ form_start(userEditionForm, {'attr': {'novalidate': 'novalidate'}}) }}
+    {{ form_start(form, {'attr': {'novalidate': 'novalidate'}}) }}
     
     <div class="form-group">
-        {{ form_label(userEditionForm.email) }}
-        {{ form_widget(userEditionForm.email, {'attr': {'class': 'form-control'}}) }}
-        {{ form_errors(userEditionForm.email) }}
+        {{ form_label(form.email) }}
+        {{ form_widget(form.email, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.email) }}
     </div>
 
     <div class="form-group">
-        {{ form_label(userEditionForm.username) }}
-        {{ form_widget(userEditionForm.username, {'attr': {'class': 'form-control'}}) }}
-        {{ form_errors(userEditionForm.username) }}
+        {{ form_label(form.username) }}
+        {{ form_widget(form.username, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.username) }}
     </div>
 
     <div class="form-group">
-        {{ form_label(userEditionForm.password.first) }}
-        {{ form_widget(userEditionForm.password.first, {'attr': {'class': 'form-control'}}) }}
-        {{ form_errors(userEditionForm.password.first) }}
+        {{ form_label(form.roles) }}
+        {{ form_widget(form.roles, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.roles) }}
     </div>
 
     <div class="form-group">
-        {{ form_label(userEditionForm.password.second) }}
-        {{ form_widget(userEditionForm.password.second, {'attr': {'class': 'form-control'}}) }}
-        {{ form_errors(userEditionForm.password.second) }}
+        {{ form_label(form.password.first) }}
+        {{ form_widget(form.password.first, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.password.first) }}
+    </div>
+
+    <div class="form-group">
+        {{ form_label(form.password.second) }}
+        {{ form_widget(form.password.second, {'attr': {'class': 'form-control'}}) }}
+        {{ form_errors(form.password.second) }}
     </div>
 
     <div class="form-group">
         <button type="submit" class="btn btn-success">Mettre à jour</button>
     </div>
 
-    {{ form_end(userEditionForm) }}
+    {{ form_end(form) }}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
rappel: 
_Lors de la création d’un utilisateur, il doit être possible de choisir un rôle pour celui-ci. Les rôles listés sont les suivants :
rôle utilisateur (ROLE_USER) ;
rôle administrateur (ROLE_ADMIN).
Lors de la modification d’un utilisateur, il est également possible de changer le rôle d’un utilisateur._


rajout hierarchie role dans security.yaml
rajout dans le formulaire du choix du role
rajout d'un model transformer dans les form car besoin d'adapter la donnée du formulaire pour l'entité mise en forme des vues